### PR TITLE
Bump python base image from 3.11 to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.13
 
 WORKDIR /app
 


### PR DESCRIPTION
Not that 3.11 is that old, but let's update them together

See also https://github.com/DigitalShoestringSolutions/sm_SensingDC/issues/6